### PR TITLE
feat(tests): add unit tests for stepper pages and composables

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,21 +7,23 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "@fontsource/roboto": "5.2.5",
     "@mdi/font": "7.4.47",
     "dayjs": "^1.11.13",
     "vue": "^3.5.13",
-    "vue-i18n": "^9.14.4",
     "vuetify": "^3.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
+    "@vitest/ui": "^3.1.4",
     "eslint": "^9.23.0",
     "eslint-config-vuetify": "^3.0.3",
     "globals": "^16.0.0",
+    "happy-dom": "^17.5.6",
     "pinia": "^3.0.1",
     "sass-embedded": "^1.86.3",
     "unplugin-auto-import": "^19.1.1",
@@ -31,6 +33,8 @@
     "vite": "^6.2.2",
     "vite-plugin-vue-layouts-next": "^0.0.8",
     "vite-plugin-vuetify": "^2.1.1",
+    "vitest": "^3.1.4",
+    "vue-i18n": "^11.1.5",
     "vue-router": "^4.5.0"
   }
 }

--- a/src/test/vitest/__tests__/useDocumentDateValidation.spec.js
+++ b/src/test/vitest/__tests__/useDocumentDateValidation.spec.js
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { useDocumentDateValidation } from '@/composables/useDocumentDateValidation'
+import dayjs from 'dayjs'
+
+describe('useDocumentDateValidation', () => {
+  let day, month, year, t, composable
+
+  beforeEach(() => {
+    day = ref(null)
+    month = ref(null)
+    year = ref(null)
+    t = key => key
+    composable = useDocumentDateValidation(t, day, month, year)
+  })
+
+  it('should initialize with empty errors and options', () => {
+    expect(composable.errors.value.general).toBe('')
+    expect(composable.monthOptions).toHaveLength(12)
+    expect(composable.yearOptions.value.length).toBeGreaterThan(0)
+    expect(composable.dayOptions.value).toEqual([])
+  })
+
+  it('should mark form as incomplete initially', () => {
+    expect(composable.isFormComplete.value).toBe(false)
+  })
+
+  it('should generate correct days for a given month and year', () => {
+    month.value = 2
+    year.value = 2020
+    composable.updateDayOptions()
+    expect(composable.dayOptions.value).toHaveLength(29)
+  })
+
+  it('should validate missing fields', () => {
+    const result = composable.validate()
+    expect(result).toBe(false)
+    expect(composable.errors.value.general).toBe('documentDate.errors.complete_all_fields')
+  })
+
+  it('should invalidate future date', () => {
+    const future = dayjs().add(1, 'day')
+    day.value = future.date()
+    month.value = future.month() + 1
+    year.value = future.year()
+    const result = composable.validate()
+    expect(result).toBe(false)
+    expect(composable.errors.value.general).toBe('documentDate.errors.date_cannot_be_future')
+  })
+
+  it('should invalidate if under 18', () => {
+    const under18 = dayjs().subtract(17, 'years')
+    day.value = under18.date()
+    month.value = under18.month() + 1
+    year.value = under18.year()
+    const result = composable.validate()
+    expect(result).toBe(false)
+    expect(composable.errors.value.general).toBe('documentDate.errors.must_be_18')
+  })
+
+  it('should pass for a valid date older than 18', () => {
+    const validDate = dayjs().subtract(20, 'years')
+    day.value = validDate.date()
+    month.value = validDate.month() + 1
+    year.value = validDate.year()
+    const result = composable.validate()
+    expect(result).toBe(true)
+    expect(composable.errors.value.general).toBe('')
+  })
+})

--- a/src/test/vitest/__tests__/useLanguageValidation.spec.js
+++ b/src/test/vitest/__tests__/useLanguageValidation.spec.js
@@ -1,0 +1,56 @@
+import { nextTick, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockLocale = ref('es')
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    locale: mockLocale,
+    t: key => {
+      const translations = {
+        'lang.es': 'Spanish',
+        'lang.en': 'English',
+      }
+      return translations[key] || key
+    },
+  }),
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+  mockLocale.value = 'es'
+})
+
+import { useLanguage } from '../../../composables/useLanguage'
+
+describe('useLanguage', () => {
+  it('returns translated labels correctly', () => {
+    const { languages } = useLanguage()
+
+    expect(languages.value).toEqual([
+      { label: 'Spanish', value: 'es' },
+      { label: 'English', value: 'en' },
+    ])
+  })
+
+  it('updates localStorage and locale when currentLang changes', async () => {
+    const { currentLang } = useLanguage()
+
+    currentLang.value = 'en'
+
+    await nextTick()
+
+    expect(localStorage.getItem('lang')).toBe('en')
+    expect(mockLocale.value).toBe('en')
+  })
+
+  it('updates currentLang if locale changes externally', async () => {
+    const { currentLang } = useLanguage()
+
+    mockLocale.value = 'en'
+
+    await nextTick()
+
+    expect(currentLang.value).toBe('en')
+  })
+})

--- a/src/test/vitest/__tests__/usePaymentDateOptions.spec.js
+++ b/src/test/vitest/__tests__/usePaymentDateOptions.spec.js
@@ -1,0 +1,71 @@
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import dayjs from 'dayjs'
+
+const mockSetPaymentDate = vi.fn()
+vi.mock('@/stores/useStepperStore', () => {
+  return {
+    useStepperStore: () => ({
+      paymentDate: '',
+      setPaymentDate: mockSetPaymentDate,
+    }),
+  }
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: key => {
+      if (key === 'paymentDate.confirmationHtml') {
+        return 'Confirmed for <day></day>'
+      }
+      return key
+    },
+  }),
+}))
+
+import { usePaymentDateOptions } from '@/composables/usePaymentDateOptions'
+
+describe('usePaymentDateOptions', () => {
+  beforeEach(() => {
+    mockSetPaymentDate.mockClear()
+  })
+
+  it('generates 3 options for the next month', () => {
+    const { options } = usePaymentDateOptions()
+    expect(options.value).toHaveLength(3)
+
+    const nextMonth = dayjs().add(1, 'month')
+    expect(options.value[0].value).toBe(dayjs(new Date(nextMonth.year(), nextMonth.month(), 4)).format('YYYY-MM-DD'))
+    expect(options.value[1].value).toBe(dayjs(new Date(nextMonth.year(), nextMonth.month(), 15)).format('YYYY-MM-DD'))
+    expect(options.value[2].value).toBe(dayjs(new Date(nextMonth.year(), nextMonth.month() + 1, 0)).format('YYYY-MM-DD'))
+  })
+
+  it('selected starts with store value and updates store when changed', async () => {
+    const { selected } = usePaymentDateOptions()
+    expect(selected.value).toBe('')
+
+    const newDate = '2025-12-15'
+    selected.value = newDate
+    await nextTick()
+    expect(mockSetPaymentDate).toHaveBeenCalledWith(newDate)
+  })
+
+  it('isValid is true only when selected has a value', () => {
+    const { selected, isValid } = usePaymentDateOptions()
+    expect(isValid.value).toBe(false)
+
+    selected.value = '2025-12-15'
+    expect(isValid.value).toBe(true)
+  })
+
+  it('confirmationMessage returns text with formatted day when selected has value', () => {
+    const { selected, confirmationMessage } = usePaymentDateOptions()
+
+    selected.value = '2025-12-15'
+    const day = dayjs(selected.value).date()
+    expect(confirmationMessage.value).toBe(`Confirmed for <span>${day}</span>`)
+
+    selected.value = ''
+    expect(confirmationMessage.value).toBe('')
+  })
+})

--- a/src/test/vitest/__tests__/useSummaryDataValidation.spec.js
+++ b/src/test/vitest/__tests__/useSummaryDataValidation.spec.js
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSummaryData } from '@/composables/useSummaryData'
+import dayjs from 'dayjs'
+
+let storeMock
+
+vi.mock('../../../stores/useStepperStore', () => {
+  return {
+    useStepperStore: () => storeMock,
+  }
+})
+
+vi.mock('vue-i18n', () => {
+  return {
+    useI18n: () => ({
+      t: key => {
+        const translations = {
+          'summary.notAvailable': 'Not available',
+        }
+        return translations[key] || key
+      },
+    }),
+  }
+})
+
+describe('useSummaryData', () => {
+  beforeEach(() => {
+    storeMock = {
+      documentDate: { day: 10, month: 5, year: 2023 },
+      paymentDate: '2023-06-15',
+      isDocumentDateValid: true,
+      reset: vi.fn(),
+      setCurrentStep: vi.fn(),
+    }
+  })
+
+  it('returns formatted issueDateText correctly', () => {
+    const { issueDateText } = useSummaryData()
+    expect(issueDateText.value).toBe(dayjs('2023-5-10', 'YYYY-M-D').format('DD-MMM-YYYY'))
+  })
+
+  it('returns "Not available" if document date is incomplete', () => {
+    storeMock.documentDate = { day: null, month: null, year: null }
+    const { issueDateText } = useSummaryData()
+    expect(issueDateText.value).toBe('Not available')
+  })
+
+  it('returns formatted paymentDateText correctly', () => {
+    const { paymentDateText } = useSummaryData()
+    expect(paymentDateText.value).toBe(dayjs('2023-06-15', 'YYYY-MM-DD').format('DD-MMM-YYYY'))
+  })
+
+  it('returns "Not available" if paymentDate is null', () => {
+    storeMock.paymentDate = null
+    const { paymentDateText } = useSummaryData()
+    expect(paymentDateText.value).toBe('Not available')
+  })
+
+  it('returns correct paymentDayText', () => {
+    const { paymentDayText } = useSummaryData()
+    expect(paymentDayText.value).toBe(15)
+  })
+
+  it('returns "Not available" for paymentDayText if paymentDate is invalid', () => {
+    storeMock.paymentDate = 'invalid-date'
+    const { paymentDayText } = useSummaryData()
+    expect(paymentDayText.value).toBe('Not available')
+  })
+
+  it('calculates isValid correctly', () => {
+    const { isValid } = useSummaryData()
+    expect(isValid.value).toBe(true)
+
+    storeMock.isDocumentDateValid = false
+    const { isValid: isValid2 } = useSummaryData()
+    expect(isValid2.value).toBe(false)
+
+    storeMock.isDocumentDateValid = true
+    storeMock.paymentDate = null
+    const { isValid: isValid3 } = useSummaryData()
+    expect(isValid3.value).toBe(false)
+  })
+
+  it('handleFinish calls reset and setCurrentStep(1)', () => {
+    const { handleFinish } = useSummaryData()
+    handleFinish()
+    expect(storeMock.reset).toHaveBeenCalled()
+    expect(storeMock.setCurrentStep).toHaveBeenCalledWith(1)
+  })
+})

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,7 +9,7 @@ import { VueRouterAutoImports } from 'unplugin-vue-router'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
 // Utilities
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
@@ -50,6 +50,17 @@ export default defineConfig({
       vueTemplate: true,
     }),
   ],
+  test: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+    environment: 'happy-dom',
+    globals: true,
+    include: [
+      'src/**/*.{test,spec}.{js,ts,jsx,tsx}',
+      'test/**/*.{test,spec}.{js,ts,jsx,tsx}',
+    ],
+  },
   optimizeDeps: {
     exclude: [
       'vuetify',


### PR DESCRIPTION
- Added tests for step navigation logic and stepper page components
- Tested composables for language, payment date options, and summary data
- Mocked stores and i18n for isolated testing
- Improved test coverage for key app workflows
- [feat(tests): add unit tests for stepper pages and composables](https://github.com/Michael98Arias/credit-flow/commit/82cf1044d7e13b949433490f0f846f8330c80309)